### PR TITLE
fix login service defintion to not use config flag

### DIFF
--- a/cmd/meeseeks/start_at_login.go
+++ b/cmd/meeseeks/start_at_login.go
@@ -66,12 +66,6 @@ func runAtLoginEnableCommand(ctx context.Context, service login.Service, args []
 		return fmt.Errorf("failed to get absolute path for config dir: %w", err)
 	}
 
-	// Convert to absolute path if not already
-	absConfigPath, err := filepath.Abs(getDefaultConfigPath())
-	if err != nil {
-		return fmt.Errorf("failed to get absolute path for config file: %w", err)
-	}
-
 	// Get current executable path
 	execPath, err := os.Executable()
 	if err != nil {
@@ -84,7 +78,6 @@ func runAtLoginEnableCommand(ctx context.Context, service login.Service, args []
 
 	// Create login service configuration
 	loginConfig := login.ServiceConfig{
-		ConfigPath:     absConfigPath,
 		ExecutablePath: absExecPath,
 		ConfigDir:      absConfigDir,
 	}
@@ -101,7 +94,7 @@ func runAtLoginEnableCommand(ctx context.Context, service login.Service, args []
 	}
 
 	fmt.Fprintf(os.Stdout, "Successfully enabled meeseeks to start at login\n")
-	fmt.Fprintf(os.Stdout, "Config file: %s\n", absConfigPath)
+	fmt.Fprintf(os.Stdout, "Config dir: %s\n", absConfigDir)
 
 	return nil
 }

--- a/internal/login/darwin.go
+++ b/internal/login/darwin.go
@@ -38,8 +38,6 @@ const launchAgentTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <array>
         <string>{{.ExecutablePath}}</string>
         <string>start</string>
-        <string>-config</string>
-        <string>{{.ConfigPath}}</string>
     </array>
     <key>RunAtLoad</key>
     <true/>

--- a/internal/login/darwin_test.go
+++ b/internal/login/darwin_test.go
@@ -3,28 +3,25 @@
 package login
 
 import (
-	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestDarwinService_Validate_ServiceAlreadyExists(t *testing.T) {
-	testDir := setupTestDir(t)
+	setupLoginTestDir(t)
+	testDir := setMeeseeksConfigDirForTest(t)
 
 	service := &darwinService{}
 
 	// Create test executable and config
 	execPath := createTestExecutable(t, testDir)
-	configPath := createTestConfig(t, testDir)
-
-	configDir := filepath.Join(testDir, "config")
+	createTestConfig(t, testDir)
 
 	ctx := t.Context()
 
 	config := ServiceConfig{
 		ExecutablePath: execPath,
-		ConfigPath:     configPath,
-		ConfigDir:      configDir,
+		ConfigDir:      testDir,
 	}
 
 	// Create the service first time

--- a/internal/login/helpers_test.go
+++ b/internal/login/helpers_test.go
@@ -8,15 +8,34 @@ import (
 	"testing"
 )
 
-func setupTestDir(t *testing.T) string {
+func setMeeseeksConfigDirForTest(t *testing.T) string {
+	t.Helper()
+
+	// Make sure running tests while having a production
+	// instance of meeseeks running do not cause problems
+	customDir := filepath.Join("/tmp/", t.Name())
+
+	err := os.MkdirAll(customDir, 0750)
+	if err != nil {
+		t.Fatalf("error creating temp folder for tests %s", err.Error())
+	}
+
+	t.Setenv("MEESEEKS_CONFIG_DIR", customDir)
+
+	t.Cleanup(func() {
+		os.RemoveAll(customDir)
+	})
+
+	return customDir
+}
+
+func setupLoginTestDir(t *testing.T) {
 	t.Helper()
 
 	testDir := t.TempDir()
 
 	// Set the test directory environment variable
 	t.Setenv("MEESEEKS_TEST_LOGIN_DIR", testDir)
-
-	return testDir
 }
 
 func createTestExecutable(t *testing.T, dir string) string {
@@ -31,7 +50,7 @@ func createTestExecutable(t *testing.T, dir string) string {
 	return execPath
 }
 
-func createTestConfig(t *testing.T, dir string) string {
+func createTestConfig(t *testing.T, dir string) {
 	t.Helper()
 
 	configPath := filepath.Join(dir, "config.yaml")
@@ -39,6 +58,4 @@ func createTestConfig(t *testing.T, dir string) string {
 	if err != nil {
 		t.Fatalf("failed to create test config: %v", err)
 	}
-
-	return configPath
 }

--- a/internal/login/linux.go
+++ b/internal/login/linux.go
@@ -33,7 +33,7 @@ Description=meeseeks process manager
 
 [Service]
 Type=simple
-ExecStart="{{.ExecutablePath}}" start -config "{{.ConfigPath}}"
+ExecStart="{{.ExecutablePath}}" start
 Restart=always
 Environment="MEESEEKS_CONFIG_DIR={{.ConfigDir}}"
 StandardOutput=append:"{{.ConfigDir}}/meeseeks.out.log"

--- a/internal/login/linux_test.go
+++ b/internal/login/linux_test.go
@@ -4,27 +4,24 @@ package login
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestLinuxService_Create_ServiceAlreadyExists(t *testing.T) {
-	testDir := setupTestDir(t)
+	setupLoginTestDir(t)
+	testDir := setMeeseeksConfigDirForTest(t)
 
 	service := &linuxService{}
 
 	execPath := createTestExecutable(t, testDir)
-	configPath := createTestConfig(t, testDir)
-
-	configDir := filepath.Join(testDir, "config")
+	createTestConfig(t, testDir)
 
 	ctx := t.Context()
 
 	config := ServiceConfig{
 		ExecutablePath: execPath,
-		ConfigPath:     configPath,
-		ConfigDir:      configDir,
+		ConfigDir:      testDir,
 	}
 
 	if _, err := service.Create(ctx, config); err != nil {
@@ -57,19 +54,17 @@ func TestLinuxService_Enable_RequiresSystemd(t *testing.T) {
 }
 
 func TestLinuxService_Create_RendersUnit(t *testing.T) {
-	testDir := setupTestDir(t)
+	setupLoginTestDir(t)
+	testDir := setMeeseeksConfigDirForTest(t)
 
 	service := &linuxService{}
 
 	execPath := createTestExecutable(t, testDir)
-	configPath := createTestConfig(t, testDir)
-
-	configDir := filepath.Join(testDir, "config")
+	createTestConfig(t, testDir)
 
 	config := ServiceConfig{
 		ExecutablePath: execPath,
-		ConfigPath:     configPath,
-		ConfigDir:      configDir,
+		ConfigDir:      testDir,
 	}
 
 	def, err := service.Create(t.Context(), config)
@@ -87,8 +82,7 @@ func TestLinuxService_Create_RendersUnit(t *testing.T) {
 		"Restart=always",
 		"WantedBy=multi-user.target",
 		execPath,
-		configPath,
-		"MEESEEKS_CONFIG_DIR=" + configDir,
+		"MEESEEKS_CONFIG_DIR=" + testDir,
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("unit file missing %q\n---\n%s", want, content)

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -31,9 +31,6 @@ type Service interface {
 // ServiceConfig contains the configuration needed to set up
 // a login service across different platforms.
 type ServiceConfig struct {
-	// ConfigPath is the absolute path to the meeseeks configuration file
-	ConfigPath string
-
 	// ExecutablePath is the absolute path to the meeseeks executable
 	ExecutablePath string
 

--- a/internal/login/windows.go
+++ b/internal/login/windows.go
@@ -60,7 +60,7 @@ const taskXMLTemplate = `<?xml version="1.0" encoding="UTF-16"?>
   <Actions>
     <Exec>
       <Command>{{.ExecutablePath}}</Command>
-      <Arguments>start -config "{{.ConfigPath}}"</Arguments>
+      <Arguments>start</Arguments>
     </Exec>
   </Actions>
 </Task>

--- a/internal/login/windows_test.go
+++ b/internal/login/windows_test.go
@@ -4,28 +4,25 @@ package login
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"unicode/utf16"
 )
 
 func TestWindowsService_Create_ServiceAlreadyExists(t *testing.T) {
-	testDir := setupTestDir(t)
+	setupLoginTestDir(t)
+	testDir := setMeeseeksConfigDirForTest(t)
 
 	service := &windowsService{}
 
 	execPath := createTestExecutable(t, testDir)
-	configPath := createTestConfig(t, testDir)
-
-	configDir := filepath.Join(testDir, "config")
+	createTestConfig(t, testDir)
 
 	ctx := t.Context()
 
 	config := ServiceConfig{
 		ExecutablePath: execPath,
-		ConfigPath:     configPath,
-		ConfigDir:      configDir,
+		ConfigDir:      testDir,
 	}
 
 	if _, err := service.Create(ctx, config); err != nil {
@@ -43,19 +40,17 @@ func TestWindowsService_Create_ServiceAlreadyExists(t *testing.T) {
 }
 
 func TestWindowsService_Create_RendersTaskXML(t *testing.T) {
-	testDir := setupTestDir(t)
+	setupLoginTestDir(t)
+	testDir := setMeeseeksConfigDirForTest(t)
 
 	service := &windowsService{}
 
 	execPath := createTestExecutable(t, testDir)
-	configPath := createTestConfig(t, testDir)
-
-	configDir := filepath.Join(testDir, "config")
+	createTestConfig(t, testDir)
 
 	config := ServiceConfig{
 		ExecutablePath: execPath,
-		ConfigPath:     configPath,
-		ConfigDir:      configDir,
+		ConfigDir:      testDir,
 	}
 
 	def, err := service.Create(t.Context(), config)
@@ -78,7 +73,6 @@ func TestWindowsService_Create_RendersTaskXML(t *testing.T) {
 		"<LogonTrigger>",
 		"<RestartOnFailure>",
 		execPath,
-		configPath,
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("task xml missing %q\n---\n%s", want, content)


### PR DESCRIPTION
In this PR https://github.com/GustavoCaso/meeseeks/pull/77 we remove the `-config` flag. 

We forgot to remove the use of the flag in the login service
